### PR TITLE
Fix TurnEngine game import

### DIFF
--- a/src/engines/turnEngine.js
+++ b/src/engines/turnEngine.js
@@ -1,5 +1,4 @@
 // src/engines/turnEngine.js
-import { game } from '../game.js';
 
 export class TurnEngine {
     constructor(player, monsterManager, mercenaryManager, eventManager) {
@@ -33,9 +32,9 @@ export class TurnEngine {
         if (!this.isPlayerTurn) { // 적 턴이 끝났을 때
             this.isPlayerTurn = true;
             this.turnNumber++;
-            this.eventManager.emit('turnEnd', { turnNumber: this.turnNumber });
-            this.eventManager.emit('playerTurnStart');
-            game.uiManager.addLog("Your turn.", "white");
+            this.eventManager.publish('turnEnd', { turnNumber: this.turnNumber });
+            this.eventManager.publish('playerTurnStart');
+            this.eventManager.publish('log', { message: 'Your turn.', color: 'white' });
         }
     }
 


### PR DESCRIPTION
## Summary
- remove unused `game` import from `TurnEngine`
- hook turn end messages into `EventManager`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857cbd5214483278c93e457b3c44467