### PR TITLE
Fix engine initialization order

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -164,6 +164,7 @@ export class Game {
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
         // this.traitManager = this.managers.TraitManager;
+        this.engineBridge = new EngineBridge();
         this.mbtiEngine = new MBTIEngine(this.eventManager, this.uiManager);
         this.engineBridge.register('mbti', this.mbtiEngine);
         this.mercenaryManager.setTraitManager(this.mbtiEngine);
@@ -177,7 +178,6 @@ export class Game {
         this.pathfindingManager = new PathfindingManager(this.mapManager);
         this.motionManager = new Managers.MotionManager(this.mapManager, this.pathfindingManager);
         // 엔진 시스템 초기화
-        this.engineBridge = new EngineBridge();
         this.movementEngine = new MovementEngine(this.mapManager);
         this.engineBridge.register('movement', this.movementEngine);
         this.vfxEngine = new VFXEngine(this.layerManager);


### PR DESCRIPTION
## Summary
- initialize EngineBridge before registering MBTI engine

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857cce9e2e88327b0ae1daca7e684cc