### PR TITLE
Fix VFXEngine layer access

### DIFF
--- a/src/managers/layerManager.js
+++ b/src/managers/layerManager.js
@@ -35,4 +35,12 @@ export class LayerManager {
             }
         }
     }
+
+    getLayer(key) {
+        const canvas = this.layers[key];
+        return {
+            canvas,
+            getContext: () => this.contexts[key]
+        };
+    }
 }


### PR DESCRIPTION
## Summary
- expose `LayerManager.getLayer` to return canvas and context
- resolves initialization error from `VFXEngine`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857ce150a6c832792df7660897a7d02