### PR TITLE
Implement Sprite and Stat engines

### DIFF
--- a/src/engines/spriteEngine.js
+++ b/src/engines/spriteEngine.js
@@ -1,0 +1,88 @@
+// src/engines/spriteEngine.js
+
+/**
+ * SpriteEngine은 게임 월드의 모든 개체(유닛, 아이템, 투사체 등)를
+ * 화면에 그리는(drawing) 역할을 전담합니다.
+ */
+export class SpriteEngine {
+    constructor(layerManager) {
+        // 레이어 매니저에서 주로 사용할 캔버스를 받아옵니다.
+        this.entityLayer = layerManager.getLayer('entity');
+        this.projectileLayer = layerManager.getLayer('vfx');
+        console.log('[SpriteEngine] Initialized.');
+    }
+
+    /**
+     * 매 프레임 호출되어 모든 월드 개체를 다시 그립니다.
+     * @param {object} context - 게임 월드 정보
+     */
+    update(context) {
+        this.draw(context);
+    }
+
+    draw(context) {
+        const {
+            camera,
+            player,
+            monsterManager,
+            mercenaryManager,
+            petManager,
+            itemManager,
+            projectileManager,
+            fogManager
+        } = context;
+
+        // === 메인 엔티티 레이어 ===
+        const mainCtx = this.entityLayer.getContext();
+        mainCtx.clearRect(0, 0, this.entityLayer.canvas.width, this.entityLayer.canvas.height);
+        mainCtx.save();
+        mainCtx.translate(-camera.x, -camera.y);
+
+        // 아이템
+        for (const item of itemManager.items) {
+            if (!fogManager || fogManager.isVisible(item.x, item.y)) {
+                if (typeof item.render === 'function') item.render(mainCtx);
+            }
+        }
+
+        // 몬스터
+        monsterManager.monsters
+            .filter(m => !m.isHidden)
+            .forEach(m => {
+                if (!fogManager || fogManager.isVisible(m.x, m.y)) m.render(mainCtx);
+            });
+
+        // 용병
+        mercenaryManager.mercenaries
+            .filter(m => !m.isHidden)
+            .forEach(m => {
+                if (!fogManager || fogManager.isVisible(m.x, m.y)) m.render(mainCtx);
+            });
+
+        // 펫
+        if (petManager?.pets) {
+            petManager.pets
+                .filter(p => !p.isHidden)
+                .forEach(p => {
+                    if (!fogManager || fogManager.isVisible(p.x, p.y)) p.render(mainCtx);
+                });
+        }
+
+        // 플레이어
+        if (player && !player.isHidden) player.render(mainCtx);
+
+        mainCtx.restore();
+
+        // === 투사체 레이어 ===
+        const projCtx = this.projectileLayer.getContext();
+        projCtx.clearRect(0, 0, this.projectileLayer.canvas.width, this.projectileLayer.canvas.height);
+        projCtx.save();
+        projCtx.translate(-camera.x, -camera.y);
+
+        if (projectileManager && typeof projectileManager.render === 'function') {
+            projectileManager.render(projCtx);
+        }
+
+        projCtx.restore();
+    }
+}

--- a/src/engines/statEngine.js
+++ b/src/engines/statEngine.js
@@ -1,0 +1,78 @@
+// src/engines/statEngine.js
+
+/**
+ * StatEngine은 개체의 능력치 계산과 버프/디버프 효과의 적용을 관리합니다.
+ * 기존 StatManager의 전역 역할을 수행하도록 설계되었습니다.
+ */
+export class StatEngine {
+    constructor() {
+        console.log('[StatEngine] Initialized.');
+    }
+
+    /**
+     * 장비 등을 고려하여 개체의 최종 능력치를 다시 계산합니다.
+     * @param {object} entity
+     */
+    recalculateStats(entity) {
+        // 기본 능력치로 초기화
+        Object.assign(entity.stats, entity.baseStats);
+
+        // 장비로 인한 변화 적용
+        if (entity.equipment) {
+            for (const slot in entity.equipment) {
+                const item = entity.equipment[slot];
+                if (item && item.stats) {
+                    for (const stat in item.stats) {
+                        entity.stats[stat] = (entity.stats[stat] || 0) + item.stats[stat];
+                    }
+                }
+            }
+        }
+        // TODO: 특성이나 버프에 의한 계산 로직 추가 가능
+    }
+
+    /**
+     * 특정 스탯 값을 가져옵니다.
+     * @param {object} entity
+     * @param {string} statName
+     * @returns {number}
+     */
+    getStat(entity, statName) {
+        return entity.stats[statName] || 0;
+    }
+
+    /**
+     * 버프/디버프 효과를 적용합니다.
+     * @param {object} entity
+     * @param {object} effect - { id, duration, stats }
+     */
+    applyEffect(entity, effect) {
+        if (!entity.effects) entity.effects = [];
+        const now = performance.now();
+        const existing = entity.effects.findIndex(e => e.id === effect.id);
+        const newEffect = { ...effect, startTime: now };
+        if (existing > -1) entity.effects[existing] = newEffect;
+        else entity.effects.push(newEffect);
+        this.recalculateStats(entity);
+    }
+
+    /**
+     * 모든 개체를 순회하며 효과 지속 시간을 관리합니다.
+     * @param {object} context
+     */
+    update(context) {
+        const { player, monsterManager, mercenaryManager } = context;
+        const entities = [player, ...monsterManager.monsters, ...mercenaryManager.mercenaries];
+        const now = performance.now();
+
+        for (const entity of entities) {
+            if (!entity.effects || entity.effects.length === 0) continue;
+            const before = entity.effects.length;
+            entity.effects = entity.effects.filter(effect => {
+                if (effect.duration === Infinity) return true;
+                return now - effect.startTime < effect.duration;
+            });
+            if (entity.effects.length !== before) this.recalculateStats(entity);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SpriteEngine to draw items, units, pets and projectiles
- create StatEngine to handle stats and buffs
- register both engines in Game initialization
- expose new stat engine and pet manager through context
- remove leftover item render call from Game.render

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857d0a4eae08327b0a7e4c93191aba5